### PR TITLE
[FIXED #101075790] Added expr field to security schema

### DIFF
--- a/schemas/security.json
+++ b/schemas/security.json
@@ -225,7 +225,8 @@
 												"name":"string"
 											}
 										}
-									}
+									},
+									"expr": "string"
 								}
 							}
 						}


### PR DESCRIPTION
- added "expr" field to security.json, mangler was removing it

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/membery/data-szh/12)

<!-- Reviewable:end -->
